### PR TITLE
Table model, extra comments

### DIFF
--- a/showcomments.py
+++ b/showcomments.py
@@ -2,16 +2,71 @@
 
 from idaapi import PluginForm
 import ida_kernwin
-from PyQt5 import QtCore, QtGui, QtWidgets
+from PyQt5 import QtCore, QtWidgets
 import idautils
 import idaapi
 import idc
 
+class Comment:
+    def __init__(self, address, comment_type, comment, function_name):
+        self.address = address
+        self.comment_type = comment_type
+        self.comment = comment
+        self.function_name = function_name
+
+class CommentTableModel(QtCore.QAbstractTableModel):
+    def __init__(self, parent=None, *args):
+        super(CommentTableModel, self).__init__()
+        self.table_data = []
+
+    def append(self, comment):
+        self.beginInsertRows(QtCore.QModelIndex(), len(self.table_data), len(self.table_data))
+        self.table_data.append(comment)
+        self.endInsertRows()
+
+    def columnCount(self, parent=QtCore.QModelIndex()):
+        return 4
+
+    def data(self, index, role=QtCore.Qt.DisplayRole):
+        if (not index.isValid()) or (role != QtCore.Qt.DisplayRole):
+            return QtCore.QVariant()
+        
+        comment = self.table_data[index.row()]
+        match index.column():
+            case 0:
+                return comment.address
+            case 1:
+                return comment.comment_type
+            case 2:
+                return comment.comment
+            case 3:
+                return comment.function_name
+            case _:
+                return QtCore.QVariant()
+
+    def dataAt(self, index):
+        return self.table_data[index.row()]
+
+    def headerData(self, column, orientation, role):
+        if (orientation != QtCore.Qt.Horizontal) or (role != QtCore.Qt.DisplayRole):
+            return QtCore.QVariant()
+        
+        match column:
+            case 0:
+                return "Address"
+            case 1:
+                return "Type"
+            case 2:
+                return "Comment"
+            case 3:
+                return "Function Name"
+            case _:
+                return QtCore.QVariant()
+
+    def rowCount(self, parent=QtCore.QModelIndex()):
+        return len(self.table_data)
+
 class ShowComments(PluginForm):
-
-    matching_items = None
-    matching_index = 0
-
     def OnCreate(self, form):
         # Get parent widget
         self.parent = self.FormToPyQtWidget(form)
@@ -20,81 +75,88 @@ class ShowComments(PluginForm):
     def PopulateForm(self):
         # Create layout
         layout = QtWidgets.QVBoxLayout()
-
-        # search query
-        self.query = QtWidgets.QLineEdit()
-        self.query.setPlaceholderText("Search...")
-        self.query.textChanged.connect(self.search)
-        self.query.returnPressed.connect(self.search_next)
-
+        # Create input for keyword
+        self.filter_input = QtWidgets.QLineEdit(self.parent)
+        self.filter_input.setPlaceholderText("Search...")
+        self.filter_input.returnPressed.connect(self.filter_comments)
+        layout.addWidget(self.filter_input)
         # table 
-        self.table = QtWidgets.QTableWidget()
-        self.table.setColumnCount(4)
+        self.table = QtWidgets.QTableView()
         self.table.setEditTriggers(QtWidgets.QTableWidget.NoEditTriggers)
-        self.table.setHorizontalHeaderLabels(["Address", "Type", "Comment", "Function Name"])
         self.table.setSortingEnabled(True)
+        # populate table
+        self.reset_and_populate()
+        self.table.doubleClicked.connect(self.fn_get_cell_Value)
+        layout.addWidget(self.table)
+        # make our created layout the dialogs layout
+        self.parent.setLayout(layout)
 
-        item_index = 0
+    def add_row(self, item_index, ea, cmt, cmt_type, function_name):
+        self.table_model.append(Comment(hex(ea), cmt_type, cmt, function_name))
+        item_index += 1
+        return item_index
+
+    def filter_comments(self):
+        if keyword := self.filter_input.text():
+            self.proxy_model.setFilterRegularExpression(keyword)
+        else:
+            self.proxy_model.setFilterRegularExpression(".*")
+
+    def populate_with_comments(self, item_index):
         current_function_name = None
-
         for ea in idautils.Heads():
             # Check if the first address of a function contains a function (repeatable) comment
             # IDAPython cheatsheet (https://gist.github.com/icecr4ck/7a7af3277787c794c66965517199fc9c)
             function_name = idaapi.get_func_name(ea)
             if function_name != current_function_name:
-                function_cmt = idc.get_func_cmt(ea, True)
-                if function_cmt:
+                if function_cmt := idc.get_func_cmt(ea, True):
                     item_index = self.add_row(item_index, ea, function_cmt, "Function", function_name)
                 current_function_name = function_name
-
-                # Check if the address contains a regular (non-repeatable) comment
-            cmt = idaapi.get_cmt(ea, False)
-            if cmt:
+            # Check if the address contains a regular (non-repeatable) comment
+            if cmt := idaapi.get_cmt(ea, False):
                 item_index = self.add_row(item_index, ea, cmt, "Regular", function_name)
             # Now check if it contains a repeatable comment
-            cmt = idaapi.get_cmt(ea, True)
-            if cmt:
+            if cmt := idaapi.get_cmt(ea, True):
                 item_index = self.add_row(item_index, ea, cmt, "Repeatable", function_name)
-                
-        self.table.resizeColumnsToContents()
-        self.table.doubleClicked.connect(self.fn_get_cell_Value)
-        layout.addWidget(self.table)
-        layout.addWidget(self.query)
+            # Now check if it contains an anterior comment
+            cmt_data = []
+            cmt_idx = 0
+            while cmt := idaapi.get_extra_cmt(ea, idaapi.E_PREV + cmt_idx):
+                cmt_data.append(cmt)
+                cmt_idx += 1
+            if cmt_data:
+                item_index = self.add_row(item_index, ea, " ".join(cmt_data), "Anterior", function_name)
+            # Finally, check if it contains a posterior comment
+            cmt_data = []
+            cmt_idx = 0
+            while cmt := idaapi.get_extra_cmt(ea, idaapi.E_NEXT + cmt_idx):
+                cmt_data.append(cmt)
+                cmt_idx += 1
+            if cmt_data:
+                item_index = self.add_row(item_index, ea, " ".join(cmt_data), "Posterior", function_name)
 
-        # make our created layout the dialogs layout
-        self.parent.setLayout(layout)
-
-    def add_row(self, item_index, ea, cmt, cmt_type, function_name):
-        self.table.insertRow(self.table.rowCount())
-        self.table.setItem(item_index, 0, QtWidgets.QTableWidgetItem(hex(ea)))
-        self.table.setItem(item_index, 1, QtWidgets.QTableWidgetItem(cmt_type))
-        self.table.setItem(item_index, 2, QtWidgets.QTableWidgetItem(cmt))
-        self.table.setItem(item_index, 3, QtWidgets.QTableWidgetItem(function_name))
-        item_index += 1
-        return item_index
-    
-    def search(self, s):
-        global matching_items
-        global matching_index
-        if not s:
-            self.table.setCurrentItem(None)
-            matching_items = None
-            return
-        matching_items = self.table.findItems(s, QtCore.Qt.MatchContains)
-        if matching_items:
-            matching_index = 0
-            self.table.setCurrentItem(matching_items[0])
-    
-    def search_next(self):
-        # If the user pressed Enter in search query, select next matching item
-        global matching_index
-        if matching_items:
-            if matching_index == len(matching_items) - 1:
-                matching_index = 0
-                self.table.setCurrentItem(matching_items[0])
-            else:
-                matching_index += 1
-                self.table.setCurrentItem(matching_items[matching_index])
+    def reset_and_populate(self):
+        # reset
+        try:
+            self.proxy_model.clear()
+            self.table.setModel(None)
+        except AttributeError:
+            pass
+        item_index = 0
+        # populate
+        self.table_model = CommentTableModel(self.table)
+        self.populate_with_comments(item_index)
+        # make proxy model
+        self.proxy_model = QtCore.QSortFilterProxyModel(self.table)
+        self.proxy_model.setFilterCaseSensitivity(QtCore.Qt.CaseInsensitive)
+        self.proxy_model.setFilterKeyColumn(2)
+        self.proxy_model.setSourceModel(self.table_model)
+        # use proxy model and resize
+        self.table.setModel(self.proxy_model)
+        self.table.resizeColumnToContents(0)
+        self.table.resizeColumnToContents(1)
+        self.table.resizeColumnToContents(2)
+        self.table.horizontalHeader().setStretchLastSection(True)
 
     def fn_get_cell_Value(self, index):
         # If the user clicked an address, follow it in IDA View
@@ -104,7 +166,6 @@ class ShowComments(PluginForm):
  
     def OnClose(self, form):
         pass
-
 
 class showcomments_plugin_t(idaapi.plugin_t):
     comment = "ShowComments"
@@ -125,7 +186,6 @@ class showcomments_plugin_t(idaapi.plugin_t):
 
     def term(self):
         return
-
 
 def PLUGIN_ENTRY():
     return showcomments_plugin_t()


### PR DESCRIPTION
This switches to using a table model for the table combined with a QSortFilterProxyModel for nice filtering and adds support for anterior and posterior comments (extra comments). The table's also sized differently compared to before, I think. Apologies for the "changing everything" commit and if I missed anything, I've been sitting on this script for ages.